### PR TITLE
Experimental code re-organization - do not merge

### DIFF
--- a/example/express.js
+++ b/example/express.js
@@ -1,0 +1,14 @@
+var osmdb = require('osm-p2p')
+var osm = osmdb('/tmp/osm-p2p')
+
+var osmRoutes = require('../routes')
+var express = require('express')
+var app = express()
+
+osmRoutes.forEach(function (route) {
+  app[route.method](route.path, route.GetRoute(osm))
+})
+
+app.listen(5000, function () {
+  console.log('osm-p2p listening on port 5000!')
+})

--- a/handlers/addChangeset.js
+++ b/handlers/addChangeset.js
@@ -1,0 +1,85 @@
+var randombytes = require('randombytes')
+
+function addChangeset (changeset, osmdb, callback) {
+  var pending = 1
+  var errors = []
+  var keys = []
+  var docs = {}
+  var changes = changeset.changes
+
+  changes.created.forEach(function (newEntity) {
+    docs[newEntity.id] = randombytes(8).toString('hex')
+    newEntity.id = docs[newEntity.id]
+  })
+
+  changes.created.forEach(function (newEntity) {
+    var id = fix(docs, newEntity)
+    pending++
+    osmdb.put(id, newEntity, function (err) {
+      if (err) errors.push(err)
+      else keys.push(id)
+      if (--pending === 0) done()
+    })
+  })
+
+  changes.modified.forEach(function (modifiedEntity) {
+    var id = fix(docs, modifiedEntity)
+    pending++
+    var opts = { links: modifiedEntity.version ? [modifiedEntity.version] : [] }
+    osmdb.put(id, modifiedEntity, opts, function (err) {
+      if (err) errors.push(err)
+      else keys.push(id)
+      if (--pending === 0) done()
+    })
+  })
+
+  changes.deleted.forEach(function (deletedEntity) {
+    var id = deletedEntity.id.replace(/^[nw]/, '')
+    pending++
+    var opts = { links: deletedEntity.version ? [deletedEntity.version] : [] }
+    osmdb.del(id, opts, function (err) {
+      if (err) errors.push(err)
+      else keys.push(id)
+      if (--pending === 0) done()
+    })
+  })
+
+  // *TODO* What if pending !== 0 here? It will just hang right now.
+  if (--pending === 0) done()
+
+  function done () {
+    if (errors.length) {
+      var err = new Error(errors.map(String).join('\n'))
+      err.statusCode = 500
+      return callback(err)
+    } else {
+      callback(null, keys)
+    }
+  }
+}
+
+function fix (docs, entity) {
+  var entityIsNode = entity.loc
+  var entityIsWay = entity.nodes
+
+  if (entityIsNode) {
+    entity.lat = entity.loc[1]
+    entity.lon = entity.loc[0]
+    entity.type = 'node'
+    delete entity.loc
+  } else if (entityIsWay) {
+    entity.type = 'way'
+    entity.refs = entity.nodes
+      .map(function (id) { return docs.hasOwnProperty(id) ? docs[id] : id })
+      .map(function (id) { return id.replace(/^[nw]/, '') })
+    delete entity.nodes
+  }
+
+  entity.timestamp = new Date().toISOString()
+  var id = entity.id
+  if (docs.hasOwnProperty(id)) id = docs[id]
+  delete entity.id
+  return id.replace(/^[nw]/, '')
+}
+
+module.exports = addChangeset

--- a/handlers/bbox_query_stream.js
+++ b/handlers/bbox_query_stream.js
@@ -1,0 +1,12 @@
+var pumpify = require('pumpify')
+var toxml = require('osm-p2p-xml')
+
+var bboxQueryStream = function (bboxString, osmdb, opts) {
+  var bbox = bboxString.split(',').map(Number)
+  var query = [[bbox[1], bbox[3]], [bbox[0], bbox[2]]] // left,bottom,right,top
+  var queryStream = osmdb.queryStream(query)
+  var queryStreamXml = pumpify(queryStream, toxml(query))
+  return queryStreamXml
+}
+
+module.exports = bboxQueryStream

--- a/handlers/capabilities.js
+++ b/handlers/capabilities.js
@@ -1,0 +1,18 @@
+var h = require('../lib/h')
+
+function capabilities () {
+  return h('?xml', { version: '1.0', encoding: 'UTF-8' }, [
+    h('osm', { version: 0.6, generator: 'osm-p2p' }, [
+      h('api', [
+        h('version', { minimum: 0.6, maximum: 0.6 }),
+        h('area', { maximum: 0.25 }), // in square degrees
+        h('waynodes', { maximum: 2000 }),
+        h('tracepoints', { per_page: 5000 }),
+        h('timeout', { seconds: 300 }),
+        h('status', { database: 'online', api: 'online', gpx: 'online' })
+      ])
+    ])
+  ])
+}
+
+module.exports = capabilities

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "minimist": "^1.2.0",
     "osm-p2p": "^1.1.0",
     "osm-p2p-xml": "^1.0.1",
+    "pumpify": "^1.3.3",
+    "query-string": "^3.0.0",
     "randombytes": "^2.0.2",
     "routes": "^2.1.0",
+    "xml": "^1.0.0",
     "xml-parser": "^1.2.1",
     "xtend": "^4.0.1"
   },

--- a/routes/get_capabilities.js
+++ b/routes/get_capabilities.js
@@ -1,0 +1,9 @@
+var capabilities = require('../handlers/capabilities')
+
+var GetCapabilitiesRoute = function () {
+  return function getCapabilitiesRoute (req, res) {
+    res.end(capabilities())
+  }
+}
+
+module.exports = GetCapabilitiesRoute

--- a/routes/get_map.js
+++ b/routes/get_map.js
@@ -1,0 +1,17 @@
+var bboxQueryStream = require('../handlers/bbox_query_stream')
+
+var GetMapRoute = function (osmdb) {
+  return function getMapRoute (req, res, next) {
+    res.setHeader('content-type', 'text/xml; charset=utf-8')
+    res.setHeader('content-disposition', 'attachment; filename="map.osm"')
+    res.setHeader('content-encoding', 'identity')
+    res.setHeader('cache-control', 'no-cache')
+
+    var bboxString = req.params.bbox
+    var resultStream = bboxQueryStream(bboxString, osmdb)
+    resultStream.once('error', next)
+    resultStream.pipe(res)
+  }
+}
+
+module.exports = GetMapRoute

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,13 @@
+module.exports = [{
+  method: 'get',
+  path: '/api/(0.6)?/capabilities',
+  GetRoute: require('./get_capabilities')
+}, {
+  method: 'get',
+  path: '/api/0.6/map?*',
+  GetRoute: require('./get_map')
+}, {
+  method: 'post',
+  path: '/api/changeset',
+  GetRoute: require('./post_changeset')
+}]

--- a/routes/post_changeset.js
+++ b/routes/post_changeset.js
@@ -1,0 +1,17 @@
+var addChangeset = require('../handlers/add_changeset')
+var body = require('body/any')
+
+function PostChangesetRoute (osmdb) {
+  return function postChangesetRoute (req, res, next) {
+    body(req, res, function (err, changeset) {
+      if (err) return next(err)
+      addChangeset(changeset, osmdb, function done (err, keys) {
+        if (err) return next(err)
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify(keys) + '\n')
+      })
+    })
+  }
+}
+
+module.exports = PostChangesetRoute


### PR DESCRIPTION
Here are some ideas for code re-organization. This branch was based on an earlier version of osm-p2p-server, so the handlers need updated.

The aims of this change are:

- separate out dependency on [`routes`](https://www.npmjs.com/package/routes)
- make it easier to use this module with other routers / web frameworks such as [Express](http://expressjs.com)
- separate out the logic that handles operations from the server code, so that, for example, the route handlers could be directly imported and used in a JS OSM client without a server
- make the code easier to read and maintain.

I'm not sure this re-organization achieves this aim, but putting this up here for discussion.

Each route has its own file/module under `routes`. It expects route parameters to be attached to `req.params` and query string parameters to be attached to `req.query`. Express and Hapi and other popular frameworks use this convention in their route handler. If the framework you want to use does not do this, you can write middleware to add those properties.

'Handlers' are the logic for operations on each route. If we wanted to, for example, modify iD Editor so that it does not interact with any server, we could replace the xhr code with `handlers/bbox_query_stream`. Handlers should not have any dependencies on server implementation, and just receive necessary params, an `osm-p2p-db` instance, and they should return a stream. Note that `handlers/addChangeset` does not currently do this - need to update that code.


