### PR TITLE
Fix a "ghost points" scenario

### DIFF
--- a/api/get_map.js
+++ b/api/get_map.js
@@ -1,6 +1,10 @@
 var collect = require('collect-stream')
 var pumpify = require('pumpify')
 var mapStream = require('through2-map')
+var through = require('through2')
+var fromArray = require('from2-array')
+
+var cmpFork = require('../lib/util').cmpFork
 
 var refs2nodes = require('../lib/util').refs2nodes
 var checkRefExist = require('../lib/check_ref_ex.js')
@@ -11,9 +15,22 @@ module.exports = function (osm) {
       cb = opts
       opts = {}
     }
+    opts.forks = opts.forks || false
+
     var query = [[bbox[1], bbox[3]], [bbox[0], bbox[2]]] // left,bottom,right,top
-    var queryStream = osm.queryStream(query, opts)
-    var queryStreamJson = pumpify.obj(queryStream, checkRefExist(osm), mapStream.obj(refs2nodes))
+    var pipeline = [
+      osm.queryStream(query, opts),
+      checkRefExist(osm),
+      mapStream.obj(refs2nodes)
+    ]
+
+    // If forks ought to be filtered out, add another step to the pipeline that
+    // does so.
+    if (!opts.forks) {
+      pipeline.push(filterForkedElementsStream())
+    }
+
+    var queryStreamJson = pumpify.obj.apply(this, pipeline)
     if (cb) {
       collect(queryStreamJson, function (err, elements) {
         if (err) return cb(err)
@@ -23,4 +40,94 @@ module.exports = function (osm) {
       return queryStreamJson
     }
   }
+}
+
+function filterForkedElementsStream () {
+  return collectTransform(filterForkedElements)
+}
+
+function filterForkedElements (elements) {
+  var latestFirst = elements.sort(cmpFork)
+  var nonForkedElements = []
+  var keepNodeRefs = {}
+  var excludeNodeRefs = {}
+  var seen = {}
+
+  // Filter out the non-latest version of each element.
+  nonForkedElements = latestFirst.filter(function (element) {
+    if (!seen[element.id]) {
+      seen[element.id] = true
+
+      // Note that all of the nodes referenced by this way should be kept.
+      if (element.type === 'way') {
+        element.nodes.forEach(function (ref) {
+          keepNodeRefs[ref] = true
+        })
+      }
+
+      return true
+    } else {
+      seen[element.id] = true
+
+      // Note that all of the nodes referenced by this way should be culled.
+      if (element.type === 'way') {
+        element.nodes.forEach(function (ref) {
+          excludeNodeRefs[ref] = true
+        })
+      }
+
+      return false
+    }
+  })
+
+  // Remove excluded entries that appear in the keep entries.
+  Object.keys(keepNodeRefs).forEach(function (ref) {
+    if (excludeNodeRefs[ref]) {
+      delete excludeNodeRefs[ref]
+    }
+  })
+
+  // Filter out all nodes that are referenced in filtered ways.
+  nonForkedElements = nonForkedElements.filter(function (elm) {
+    if (elm.type === 'node' && (keepNodeRefs[elm.id] || !excludeNodeRefs[elm.id])) {
+      return true
+    } else if (elm.type !== 'node') {
+      return true
+    } else {
+      return false
+    }
+  })
+
+  // Sort by type
+  nonForkedElements.sort(cmpType)
+
+  return nonForkedElements
+}
+
+var typeOrder = { node: 0, way: 1, relation: 2 }
+function cmpType (a, b) {
+  return typeOrder[a.type] - typeOrder[b.type]
+}
+
+// Transform stream that performs 'fn' on an array of all elements in the
+// stream, and then passes on the resulting array onto the other end of the
+// stream.
+function collectTransform (fn) {
+  var elements = []
+
+  function write (elm, enc, next) {
+    elements.push(elm)
+    next()
+  }
+
+  function end (flush) {
+    elements = fn(elements)
+    var that = this
+    elements.forEach(function (elm) {
+      that.push(elm)
+    })
+    flush()
+  }
+
+  return through.obj(write, end)
 }

--- a/api/get_map.js
+++ b/api/get_map.js
@@ -1,7 +1,6 @@
 var collect = require('collect-stream')
 var pumpify = require('pumpify')
 var mapStream = require('through2-map')
-var fromArray = require('from2-array')
 var collectTransform = require('../lib/collect-transform-stream')
 var filterForkedElements = require('../lib/filter_forked_elements')
 

--- a/api/get_map.js
+++ b/api/get_map.js
@@ -1,8 +1,8 @@
 var collect = require('collect-stream')
 var pumpify = require('pumpify')
 var mapStream = require('through2-map')
-var through = require('through2')
 var fromArray = require('from2-array')
+var collectTransform = require('../lib/collect-transform-stream')
 
 var cmpFork = require('../lib/util').cmpFork
 
@@ -107,27 +107,4 @@ function filterForkedElements (elements) {
 var typeOrder = { node: 0, way: 1, relation: 2 }
 function cmpType (a, b) {
   return typeOrder[a.type] - typeOrder[b.type]
-}
-
-// Transform stream that performs 'fn' on an array of all elements in the
-// stream, and then passes on the resulting array onto the other end of the
-// stream.
-function collectTransform (fn) {
-  var elements = []
-
-  function write (elm, enc, next) {
-    elements.push(elm)
-    next()
-  }
-
-  function end (flush) {
-    elements = fn(elements)
-    var that = this
-    elements.forEach(function (elm) {
-      that.push(elm)
-    })
-    flush()
-  }
-
-  return through.obj(write, end)
 }

--- a/lib/collect-transform-stream.js
+++ b/lib/collect-transform-stream.js
@@ -1,0 +1,24 @@
+var through = require('through2')
+
+// Transform stream that performs 'fn' on an array of all elements in the
+// stream, and then passes on the resulting array onto the other end of the
+// stream.
+module.exports = function (fn) {
+  var elements = []
+
+  function write (elm, enc, next) {
+    elements.push(elm)
+    next()
+  }
+
+  function end (flush) {
+    elements = fn(elements)
+    var that = this
+    elements.forEach(function (elm) {
+      that.push(elm)
+    })
+    flush()
+  }
+
+  return through.obj(write, end)
+}

--- a/lib/filter_forked_elements.js
+++ b/lib/filter_forked_elements.js
@@ -40,13 +40,6 @@ module.exports = function (elements) {
     }
   })
 
-  // Remove excluded entries that appear in the keep entries.
-  Object.keys(keepNodeRefs).forEach(function (ref) {
-    if (excludeNodeRefs[ref]) {
-      delete excludeNodeRefs[ref]
-    }
-  })
-
   // Filter out all nodes that are referenced in filtered ways.
   nonForkedElements = nonForkedElements.filter(function (elm) {
     if (elm.type === 'node' && (keepNodeRefs[elm.id] || !excludeNodeRefs[elm.id])) {

--- a/lib/filter_forked_elements.js
+++ b/lib/filter_forked_elements.js
@@ -1,0 +1,70 @@
+var cmpFork = require('../lib/util').cmpFork
+
+// Function that consumes an array of OSM elements (ways, nodes, etc) and
+// filters out those with duplicate OSM IDs, keeping only the latest element
+// for each present OSM ID.
+//
+// Note that this will also filter out nodes belonging to ways that are
+// filtered.
+module.exports = function (elements) {
+  var latestFirst = elements.sort(cmpFork)
+  var nonForkedElements = []
+  var keepNodeRefs = {}
+  var excludeNodeRefs = {}
+  var seen = {}
+
+  // Filter out the non-latest version of each element.
+  nonForkedElements = latestFirst.filter(function (element) {
+    if (!seen[element.id]) {
+      seen[element.id] = true
+
+      // Note that all of the nodes referenced by this way should be kept.
+      if (element.type === 'way') {
+        element.nodes.forEach(function (ref) {
+          keepNodeRefs[ref] = true
+        })
+      }
+
+      return true
+    } else {
+      seen[element.id] = true
+
+      // Note that all of the nodes referenced by this way should be culled.
+      if (element.type === 'way') {
+        element.nodes.forEach(function (ref) {
+          excludeNodeRefs[ref] = true
+        })
+      }
+
+      return false
+    }
+  })
+
+  // Remove excluded entries that appear in the keep entries.
+  Object.keys(keepNodeRefs).forEach(function (ref) {
+    if (excludeNodeRefs[ref]) {
+      delete excludeNodeRefs[ref]
+    }
+  })
+
+  // Filter out all nodes that are referenced in filtered ways.
+  nonForkedElements = nonForkedElements.filter(function (elm) {
+    if (elm.type === 'node' && (keepNodeRefs[elm.id] || !excludeNodeRefs[elm.id])) {
+      return true
+    } else if (elm.type !== 'node') {
+      return true
+    } else {
+      return false
+    }
+  })
+
+  // Sort by type
+  nonForkedElements.sort(cmpType)
+
+  return nonForkedElements
+}
+
+var typeOrder = { node: 0, way: 1, relation: 2 }
+function cmpType (a, b) {
+  return typeOrder[a.type] - typeOrder[b.type]
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "concat-stream": "^1.6.0",
     "content-type": "^1.0.2",
     "express": "^4.14.0",
     "fd-chunk-store": "^2.0.0",
@@ -59,6 +60,7 @@
     "memdb": "^1.3.1",
     "osm-p2p": "^1.4.0",
     "osm-p2p-db": "^3.9.1",
+    "run-waterfall": "^1.1.3",
     "standard": "^8.0.0",
     "tape": "^4.4.0",
     "xml-parser": "^1.2.1"

--- a/routes/misc_map.js
+++ b/routes/misc_map.js
@@ -91,7 +91,13 @@ module.exports = function (req, res, api, params, next) {
 
     // Filter out all nodes that are referenced in filtered ways.
     nonForkedElements = nonForkedElements.filter(function (elm) {
-      return elm.type !== 'node' || keepNodeRefs[elm.id]
+      if (elm.type === 'node' && (keepNodeRefs[elm.id] || !excludeNodeRefs[elm.id])) {
+        return true
+      } else if (elm.type !== 'node') {
+        return true
+      } else {
+        return false
+      }
     })
 
     return nonForkedElements

--- a/routes/misc_map.js
+++ b/routes/misc_map.js
@@ -1,9 +1,7 @@
 var qs = require('query-string')
 var toOsm = require('obj2osm')
-var fromArray = require('from2-array')
 var accepts = require('accepts')
 
-var cmpFork = require('../lib/util').cmpFork
 var OsmJSONStream = require('../lib/util').OsmJSONStream
 var errors = require('../errors')
 
@@ -23,95 +21,22 @@ module.exports = function (req, res, api, params, next) {
     bounds: {minlon: bbox[0], minlat: bbox[1], maxlon: bbox[2], maxlat: bbox[3]}
   }
 
-  if (query.forks) {
-    var source = api.getMap(bbox, {order: 'type'})
-    streamResponse(source)
-  } else {
-    api.getMap(bbox, function (err, elements) {
-      if (err) return next(err)
-      var noForks = filterForkElements(elements)
-      var byType = noForks.sort(cmpType)
-      var source = fromArray.obj(byType).on('error', next)
-      streamResponse(source)
-    })
+  var source = api.getMap(bbox, {order: 'type', forks: query.forks})
+
+  var formatTransform
+  switch (accept.types(['xml', 'json'])) {
+    case 'json':
+      formatTransform = OsmJSONStream(toOsmOptions)
+      res.setHeader('content-type', 'application/json; charset=utf-8')
+      break
+    case 'xml':
+    default:
+      formatTransform = toOsm(toOsmOptions)
+      res.setHeader('content-type', 'text/xml; charset=utf-8')
+      break
   }
-
-  function streamResponse (source) {
-    var formatTransform
-    switch (accept.types(['xml', 'json'])) {
-      case 'json':
-        formatTransform = OsmJSONStream(toOsmOptions)
-        res.setHeader('content-type', 'application/json; charset=utf-8')
-        break
-      case 'xml':
-      default:
-        formatTransform = toOsm(toOsmOptions)
-        res.setHeader('content-type', 'text/xml; charset=utf-8')
-        break
-    }
-    formatTransform.on('error', next)
-    source.pipe(formatTransform).pipe(res)
-  }
-
-  function filterForkElements (elements) {
-    var latestFirst = elements.sort(cmpFork)
-    var nonForkedElements = []
-    var keepNodeRefs = {}
-    var excludeNodeRefs = {}
-    var seen = {}
-
-    // Filter out the non-latest version of each element.
-    nonForkedElements = latestFirst.filter(function (element) {
-      if (!seen[element.id]) {
-        seen[element.id] = true
-
-        // Note that all of the nodes referenced by this way should be kept.
-        if (element.type === 'way') {
-          element.nodes.forEach(function (ref) {
-            keepNodeRefs[ref] = true
-          })
-        }
-
-        return true
-      } else {
-        seen[element.id] = true
-
-        // Note that all of the nodes referenced by this way should be culled.
-        if (element.type === 'way') {
-          element.nodes.forEach(function (ref) {
-            excludeNodeRefs[ref] = true
-          })
-        }
-
-        return false
-      }
-    })
-
-    // Remove excluded entries that appear in the keep entries.
-    Object.keys(keepNodeRefs).forEach(function (ref) {
-      if (excludeNodeRefs[ref]) {
-        delete excludeNodeRefs[ref]
-      }
-    })
-
-    // Filter out all nodes that are referenced in filtered ways.
-    nonForkedElements = nonForkedElements.filter(function (elm) {
-      if (elm.type === 'node' && (keepNodeRefs[elm.id] || !excludeNodeRefs[elm.id])) {
-        return true
-      } else if (elm.type !== 'node') {
-        return true
-      } else {
-        return false
-      }
-    })
-
-    return nonForkedElements
-  }
-}
-
-var typeOrder = { node: 0, way: 1, relation: 2 }
-function cmpType (a, b) {
-  return typeOrder[a.type] - typeOrder[b.type]
+  formatTransform.on('error', next)
+  source.pipe(formatTransform).pipe(res)
 }
 
 function isValidBbox (bbox) {

--- a/routes/misc_map.js
+++ b/routes/misc_map.js
@@ -15,8 +15,6 @@ module.exports = function (req, res, api, params, next) {
   if (!isValidBbox(bbox)) {
     return next(new errors.InvalidBbox())
   }
-  res.setHeader('content-type', 'text/xml; charset=utf-8')
-  res.setHeader('content-disposition', 'attachment; filename="map.osm"')
   var toOsmOptions = {
     bounds: {minlon: bbox[0], minlat: bbox[1], maxlon: bbox[2], maxlat: bbox[3]}
   }
@@ -32,6 +30,7 @@ module.exports = function (req, res, api, params, next) {
     case 'xml':
     default:
       formatTransform = toOsm(toOsmOptions)
+      res.setHeader('content-disposition', 'attachment; filename="map.osm"')
       res.setHeader('content-type', 'text/xml; charset=utf-8')
       break
   }

--- a/routes/misc_map.js
+++ b/routes/misc_map.js
@@ -61,7 +61,6 @@ function cmpType (a, b) {
 }
 
 function isValidBbox (bbox) {
-  console.log(bbox)
   return bbox.length === 4 &&
     bbox[0] >= -180 && bbox[0] <= 180 &&
     bbox[2] >= -180 && bbox[2] <= 180 &&

--- a/test/api/get_map.test.js
+++ b/test/api/get_map.test.js
@@ -16,7 +16,7 @@ test('getMap', t => {
   var mockedOsm = {
     queryStream: function (query, opts) {
       t.deepEqual(query, expectedQuery, 'calls osm.queryStream with correct query')
-      t.deepEqual(opts, {order: 'type'}, 'calls osm.queryStream with opts order: type')
+      t.deepEqual(opts, {order: 'type', forks: false}, 'calls osm.queryStream with opts order: type')
       return through()
     }
   }

--- a/test/bbox.js
+++ b/test/bbox.js
@@ -240,7 +240,6 @@ test('bbox json /w forks', function (t) {
   }))
 })
 
-
 test('bbox.js: teardown server', function (t) {
   server.cleanup(function () {
     t.end()

--- a/test/bbox.js
+++ b/test/bbox.js
@@ -209,6 +209,38 @@ test('bbox json', function (t) {
   }))
 })
 
+test('bbox json /w forks', function (t) {
+  t.plan(7 + SIZE * 3)
+  var href = base + 'map?bbox=-123,63,-120,66&forks=true'
+  var hq = hyperquest(href, {headers: { 'Accept': 'application/json' }})
+  hq.once('response', function (res) {
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-type'].split(/\s*;\s*/)[0], 'application/json')
+  })
+  hq.pipe(concat({ encoding: 'string' }, function (body) {
+    var json = JSON.parse(body)
+    t.equal(json.version, 0.6)
+    t.deepEqual(json.bounds, { maxlat: 66, maxlon: -120, minlat: 63, minlon: -123 }, 'bounds matches request')
+    t.ok(orderedTypes(json.elements.map(function (c) {
+      return c.type
+    })), 'ordered types')
+
+    for (var i = 0; i < json.elements.length; i++) {
+      var c = json.elements[i]
+      var node = uploaded[c.id]
+      if (c.type === 'node') {
+        t.equal(c.changeset, node.changeset)
+        t.equal(c.lat, node.lat)
+        t.equal(c.lon, node.lon)
+      } else if (c.type === 'way') {
+        t.equal(c.nodes.length, SIZE, 'way')
+        t.deepEqual(c.nodes, node.refs, 'way refs')
+      }
+    }
+  }))
+})
+
+
 test('bbox.js: teardown server', function (t) {
   server.cleanup(function () {
     t.end()

--- a/test/ghost_points.js
+++ b/test/ghost_points.js
@@ -155,10 +155,10 @@ test('doesn\'t return both forked ways', function (t) {
   }
 
   // 9. Run an http query on the server to see which way & points are returned
-  function step9 (server) {
+  function step9 (d) {
     var opts = {
       hostname: 'localhost',
-      port: url.parse(server.base).port,
+      port: url.parse(d.base).port,
       path: '/api/0.6/map?bbox=-90,-90,90,90',
       headers: {
         'Accept': 'application/json'
@@ -184,6 +184,8 @@ test('doesn\'t return both forked ways', function (t) {
         } else {
           t.error('unexpected way version id')
         }
+
+        d.server.cleanup(function () {})
       }))
     })
   }

--- a/test/ghost_points.js
+++ b/test/ghost_points.js
@@ -11,12 +11,15 @@ var waterfall = require('run-waterfall')
 
 var tmpdir = require('os').tmpdir()
 var createServer = require('./lib/test_server.js')
+var slowdb = require('./lib/slowdb.js')
+
+var DELAY = process.env.OSM_P2P_DB_DELAY
 
 function createOsm () {
   var storefile = path.join(tmpdir, 'osm-store-' + Math.random())
   return osmdb({
     log: hyperlog(memdb(), { valueEncoding: 'json' }),
-    db: memdb(),
+    db: DELAY ? slowdb({delay: DELAY}) : memdb(),
     store: fdstore(4096, storefile)
   })
 }

--- a/test/ghost_points.js
+++ b/test/ghost_points.js
@@ -30,7 +30,7 @@ function createOsm () {
 }
 
 test('do not include points from an excluded way fork', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   // Has the base way
   var osmBase = createOsm()

--- a/test/ghost_points.js
+++ b/test/ghost_points.js
@@ -29,7 +29,7 @@ function createOsm () {
   })
 }
 
-test('doesn\'t return both forked ways', function (t) {
+test('do not include points from an excluded way fork', function (t) {
   t.plan(3)
 
   // Has the base way

--- a/test/ghost_points.js
+++ b/test/ghost_points.js
@@ -233,10 +233,7 @@ test('no extra points from forks /w 1 deleted node and 1 modified node', functio
   var wayId
   var wayVersionId
   var keyIds
-  var forkARefs
-  var forkAWayVersionId
   var forkBRefs
-  var forkBWayVersionId
   var osmServer
 
   // Run the test steps
@@ -289,7 +286,6 @@ test('no extra points from forks /w 1 deleted node and 1 modified node', functio
         refs[2] = keys[0]
         updateWay(osmForkA, wayId, wayVersionId, refs, cs, function (err, way) {
           t.error(err)
-          forkAWayVersionId = way.key
           done()
         })
       })
@@ -309,7 +305,6 @@ test('no extra points from forks /w 1 deleted node and 1 modified node', functio
         t.error(err)
         forkBRefs = keyIds.slice(0, 2)
         updateWay(osmForkB, wayId, wayVersionId, keyIds.slice(0, 2), cs, function (err, way) {
-          forkBWayVersionId = way.key
           done(err)
         })
       })
@@ -389,7 +384,7 @@ function deleteNode (osm, nodeId, changesetId, done) {
   var op = {
     type: 'del',
     key: nodeId,
-    value: { type: 'node', changeset: changesetId },
+    value: { type: 'node', changeset: changesetId }
   }
   osm.batch([op], done)
 }

--- a/test/ghost_points.js
+++ b/test/ghost_points.js
@@ -394,6 +394,7 @@ function createNodes (osm, nodes, changesetId, done) {
     var node = nodes.shift()
     if (!node) return done(keys)
     node.changeset = changesetId
+    node.timestamp = new Date().getTime()
     osm.create(node, function (err, key) {
       if (err) return done(err)
       keys.push(key)
@@ -417,7 +418,8 @@ function createWay (osm, nodeIds, changesetId, done) {
   osm.create({
     type: 'way',
     refs: nodeIds,
-    changeset: changesetId
+    changeset: changesetId,
+    timestamp: new Date().getTime()
   }, function (err, key, node) {
     done(err, key, node.key)
   })

--- a/test/ghost_points.js
+++ b/test/ghost_points.js
@@ -1,0 +1,265 @@
+var test = require('tape')
+var hyperlog = require('hyperlog')
+var memdb = require('memdb')
+var path = require('path')
+var fdstore = require('fd-chunk-store')
+var osmdb = require('osm-p2p-db')
+var http = require('http')
+var url = require('url')
+var concat = require('concat-stream')
+
+var through = require('through2')
+var Duplex = require('readable-stream/duplex')
+var tmpdir = require('os').tmpdir()
+var createGetMap = require('../api/get_map')
+var createServer = require('./lib/test_server.js')
+
+function getMap (osm, bbox, done) {
+  var getMap = createGetMap(osm)
+  getMap(bbox, {order: 'type'}, done)
+}
+
+function createOsm () {
+  var storefile = path.join(tmpdir, 'osm-store-' + Math.random())
+  return osmdb({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb(),
+    store: fdstore(4096, storefile)
+  })
+}
+
+test('doesn\'t return both forked ways', function (t) {
+  t.plan(3)
+
+  // Has the base way
+  var osmBase = createOsm()
+
+  // Has a fork of the base way
+  var osmForkA = createOsm()
+
+  // Has a different fork of the base way
+  var osmForkB = createOsm()
+
+  var nodes = [
+    {
+      type: 'node',
+      lon: 0,
+      lat: -1
+    },
+    {
+      type: 'node',
+      lon: 0,
+      lat: 0
+    },
+    {
+      type: 'node',
+      lon: 0,
+      lat: 1
+    },
+  ]
+
+  // 1. Create base way
+  var wayId
+  var wayVersionId
+  var changesetId
+  var keyIds
+  var forkARefs
+  var forkAWayVersionId
+  var forkBRefs
+  var forkBWayVersionId
+  function step1 () {
+    createChangeset(osmBase, function (cs) {
+      changesetId = cs
+      createNodes(osmBase, nodes, cs, function (keys) {
+        keyIds = keys
+        createWay(osmBase, keys, cs, function (way, wayVersion) {
+          wayId = way
+          wayVersionId = wayVersion
+          step2()
+        })
+      })
+    })
+  }
+
+  // 2. Replicate base osm to fork A osm
+  function step2 () {
+    sync(osmBase.log, osmForkA.log, function (err) {
+      step3()
+    })
+  }
+
+  // 3. Write modifications to fork A
+  function step3 () {
+    var node = {
+      type: 'node',
+      lon: 10,
+      lat: 10
+    }
+    createChangeset(osmForkA, function (cs) {
+      createNodes(osmForkA, [node], cs, function (keys) {
+        var refs = keyIds.concat(keys)
+        forkARefs = refs
+        updateWay(osmForkA, wayId, wayVersionId, refs, cs, function (way) {
+          forkAWayVersionId = way.key
+          step4()
+        })
+      })
+    })
+  }
+
+  // 4. Replicate base osm to fork B osm
+  function step4 () {
+    sync(osmBase.log, osmForkB.log, function (err) {
+      step5()
+    })
+  }
+
+  // 5. Write modifications to fork B
+  function step5 () {
+    var node = {
+      type: 'node',
+      lon: -10,
+      lat: -10
+    }
+    createChangeset(osmForkB, function (cs) {
+      createNodes(osmForkB, [node], cs, function (keys) {
+        var refs = keyIds.concat(keys)
+        forkBRefs = refs
+        updateWay(osmForkB, wayId, wayVersionId, refs, cs, function (way) {
+          forkBWayVersionId = way.key
+          step6()
+        })
+      })
+    })
+  }
+
+  // 6. Replicate fork A and fork B
+  function step6 () {
+    sync(osmForkA.log, osmForkB.log, function (err) {
+      step7()
+    })
+  }
+
+  // 7. Create an osm-p2p-server instance from fork A
+  function step7 () {
+    createServer(step8)
+  }
+
+  // 8. Replicate fork A and the server
+  function step8 (d) {
+    sync(d.osm.log, osmForkA.log, function (err) {
+      d.osm.ready(function () {
+        step9(d)
+      })
+    })
+  }
+
+  // 9. Run an http query on the server to see which way & points are returned
+  function step9 (server) {
+    var opts = {
+      hostname: 'localhost',
+      port: url.parse(server.base).port,
+      path: '/api/0.6/map?bbox=-90,-90,90,90',
+      headers: {
+        'Accept': 'application/json'
+      }
+    }
+    http.get(opts, function (res) {
+      res.pipe(concat(function (json) {
+        var data = JSON.parse(json)
+        var nodeIds = data.elements
+          .filter(function (elm) { return elm.type === 'node' })
+          .map(function (elm) { return elm.id })
+        var ways = data.elements.filter(function (elm) { return elm.type === 'way' })
+
+        t.equal(ways.length, 1)
+
+        // Ensure the way present matches one of the two possible forks and its nodes
+        if (ways[0].version === forkAWayVersionId) {
+          t.equal(ways[0].version, forkAWayVersionId)
+          t.deepEqual(nodeIds.sort(), forkARefs.sort())
+        } else if (ways[0].version == forkBWayVersionId) {
+          t.equal(ways[0].version, forkBWayVersionId)
+          t.deepEqual(nodeIds.sort(), forkBRefs.sort())
+        } else {
+          t.error('unexpected way version id')
+        }
+      }))
+    })
+  }
+
+  step1()
+})
+
+function eqtype (t) {
+  return function (node) { return node.type === t }
+}
+
+// creates a list of nodes
+function createNodes (osm, nodes, changesetId, done) {
+  var keys = []
+  ;(function next () {
+    var node = nodes.shift()
+    if (!node) return done(keys)
+    node.changeset = changesetId
+    osm.create(node, function (err, key) {
+      keys.push(key)
+      next()
+    })
+  })()
+}
+
+// creates a changeset with a way and nodes
+function createWay (osm, nodeIds, changesetId, done) {
+  osm.create({
+    type: 'way',
+    refs: nodeIds,
+    changeset: changesetId
+  }, function (err, key, node) {
+    done(key, node.key)
+  })
+}
+
+// updates a changeset with a way and nodes
+function updateWay (osm, way, parentId, refs, changesetId, done) {
+  osm.put(way, {
+    type: 'way',
+    refs: refs,
+    changeset: changesetId
+  },
+  { links: [parentId] },
+  function (err, way) {
+    done(way)
+  })
+}
+
+// create a new changeset
+function createChangeset (osm, done) {
+  osm.create({
+    type: 'changeset'
+  }, function (err, key, node) {
+    done(key, node.key)
+  })
+}
+
+function sync (log1, log2, done) {
+  var r1 = log1.replicate()
+  r1.on('end', onEnd)
+  r1.on('error', onEnd)
+
+  var r2 = log2.replicate()
+  r2.on('end', onEnd)
+  r2.on('error', onEnd)
+
+  r1.pipe(r2).pipe(r1)
+
+  var pending = 2
+  function onEnd (err) {
+    if (err) {
+      return done(err)
+    }
+    if (--pending === 0) {
+      return done()
+    }
+  }
+}

--- a/test/lib/filter_forked_elements.test.js
+++ b/test/lib/filter_forked_elements.test.js
@@ -1,0 +1,136 @@
+var test = require('tape')
+
+var filterForkedElements = require('../../lib/filter_forked_elements')
+
+test('duplicate nodes', function (t) {
+  var elements = [
+    {
+      type: 'node',
+      id: '123',
+      version: 'foo',
+      lon: 0,
+      lat: 0
+    },
+    {
+      type: 'node',
+      id: '123',
+      version: 'bar',
+      lon: 1,
+      lat: 1
+    },
+  ]
+
+  var expected = [elements[1]]
+
+  var actual = filterForkedElements(elements)
+
+  t.deepEqual(actual, expected)
+  t.end()
+})
+
+test('non-duplicate nodes', function (t) {
+  var elements = [
+    {
+      type: 'node',
+      id: '200',
+      version: 'foo',
+      lon: 0,
+      lat: 0
+    },
+    {
+      type: 'node',
+      id: '123',
+      version: 'bar',
+      lon: 1,
+      lat: 1
+    },
+  ]
+
+  var expected = elements
+
+  var actual = filterForkedElements(elements)
+
+  t.deepEqual(actual, expected)
+  t.end()
+})
+
+test('disparate ways', function (t) {
+  var elements = [
+    {
+      type: 'way',
+      id: '100',
+      version: 'boop',
+      nodes: ['123']
+    },
+    {
+      type: 'way',
+      id: '101',
+      version: 'beep',
+      nodes: ['124']
+    },
+    {
+      type: 'node',
+      id: '123',
+      version: 'foo',
+      lon: 0,
+      lat: 0
+    },
+    {
+      type: 'node',
+      id: '124',
+      version: 'bar',
+      lon: 1,
+      lat: 1
+    },
+  ]
+
+  var expected = elements
+
+  var actual = filterForkedElements(elements)
+
+  t.deepEqual(actual.sort(cmpElement), expected.sort(cmpElement))
+  t.end()
+})
+
+test('forked ways', function (t) {
+  var elements = [
+    {
+      type: 'way',
+      id: '100',
+      version: 'boop',
+      nodes: ['123', '124']
+    },
+    {
+      type: 'way',
+      id: '100',
+      version: 'beep',
+      nodes: ['123']
+    },
+    {
+      type: 'node',
+      id: '123',
+      version: 'foo',
+      lon: 0,
+      lat: 0
+    },
+    {
+      type: 'node',
+      id: '124',
+      version: 'bar',
+      lon: 1,
+      lat: 1
+    },
+  ]
+
+  var expected = elements.slice(1, 3)
+
+  var actual = filterForkedElements(elements)
+
+  t.deepEqual(actual.sort(cmpElement), expected.sort(cmpElement))
+  t.end()
+})
+
+function cmpElement (a, b) {
+  if (a.id === b.id) return b.version - a.version
+  else return b.id - a.id
+}

--- a/test/lib/filter_forked_elements.test.js
+++ b/test/lib/filter_forked_elements.test.js
@@ -130,6 +130,44 @@ test('forked ways', function (t) {
   t.end()
 })
 
+test('forked ways /w a delete', function (t) {
+  var elements = [
+    {
+      type: 'way',
+      id: '100',
+      version: 'boop',
+      nodes: ['123', '124']
+    },
+    {
+      type: 'way',
+      id: '100',
+      version: 'beep',
+      nodes: ['123']
+    },
+    {
+      type: 'node',
+      id: '123',
+      version: 'foo',
+      lon: 0,
+      lat: 0
+    },
+    {
+      type: 'node',
+      id: '124',
+      version: 'bar',
+      lon: 1,
+      lat: 1
+    }
+  ]
+
+  var expected = elements.slice(1, 3)
+
+  var actual = filterForkedElements(elements)
+
+  t.deepEqual(actual.sort(cmpElement), expected.sort(cmpElement))
+  t.end()
+})
+
 function cmpElement (a, b) {
   if (a.id === b.id) return b.version - a.version
   else return b.id - a.id

--- a/test/lib/filter_forked_elements.test.js
+++ b/test/lib/filter_forked_elements.test.js
@@ -17,7 +17,7 @@ test('duplicate nodes', function (t) {
       version: 'bar',
       lon: 1,
       lat: 1
-    },
+    }
   ]
 
   var expected = [elements[1]]
@@ -43,7 +43,7 @@ test('non-duplicate nodes', function (t) {
       version: 'bar',
       lon: 1,
       lat: 1
-    },
+    }
   ]
 
   var expected = elements
@@ -81,7 +81,7 @@ test('disparate ways', function (t) {
       version: 'bar',
       lon: 1,
       lat: 1
-    },
+    }
   ]
 
   var expected = elements
@@ -119,7 +119,7 @@ test('forked ways', function (t) {
       version: 'bar',
       lon: 1,
       lat: 1
-    },
+    }
   ]
 
   var expected = elements.slice(1, 3)

--- a/test/lib/slowdb.js
+++ b/test/lib/slowdb.js
@@ -1,0 +1,34 @@
+var memdb = require('memdb')
+var EventEmitter = require('events').EventEmitter
+
+function slowdb (opts) {
+  opts = opts || {}
+  var delay = opts.delay || 100
+  var db = memdb()
+  var slowdb = new EventEmitter()
+  slowdb.setMaxListeners(Infinity)
+  slowdb.db = {}
+  slowdb.db.get = function (key, opts, cb) {
+    setTimeout(function () {
+      db.db.get(key, opts, cb)
+    }, Math.random() * delay)
+  }
+  slowdb.db.put = function (key, value, opts, cb) {
+    setTimeout(function () {
+      db.db.put(key, value, opts, cb)
+    }, Math.random() * delay)
+  }
+  slowdb.db.del = db.db.del.bind(db.db)
+  slowdb.db.batch = db.db.batch.bind(db.db)
+  slowdb.db.iterator = db.db.iterator.bind(db.db)
+  slowdb.get = db.get.bind(db)
+  slowdb.put = db.put.bind(db)
+  slowdb.del = db.del.bind(db)
+  slowdb.batch = db.batch.bind(db)
+  slowdb.createReadStream = db.createReadStream.bind(db)
+  slowdb.isOpen = db.isOpen.bind(db)
+  db.on('open', slowdb.emit.bind(slowdb, 'open'))
+  return slowdb
+}
+
+module.exports = slowdb

--- a/test/lib/test_server.js
+++ b/test/lib/test_server.js
@@ -7,9 +7,10 @@ var osmdb = require('osm-p2p-db')
 var memdb = require('memdb')
 var hyperlog = require('hyperlog')
 var fdstore = require('fd-chunk-store')
-var EventEmitter = require('events').EventEmitter
 
 var osmrouter = require('../../')
+var slowdb = require('./slowdb.js')
+
 var DELAY = process.env.OSM_P2P_DB_DELAY
 
 function testServer (cb) {
@@ -44,36 +45,6 @@ function testServer (cb) {
       base: base
     })
   })
-}
-
-function slowdb (opts) {
-  opts = opts || {}
-  var delay = opts.delay || 100
-  var db = memdb()
-  var slowdb = new EventEmitter()
-  slowdb.setMaxListeners(Infinity)
-  slowdb.db = {}
-  slowdb.db.get = function (key, opts, cb) {
-    setTimeout(function () {
-      db.db.get(key, opts, cb)
-    }, Math.random() * delay)
-  }
-  slowdb.db.put = function (key, value, opts, cb) {
-    setTimeout(function () {
-      db.db.put(key, value, opts, cb)
-    }, Math.random() * delay)
-  }
-  slowdb.db.del = db.db.del.bind(db.db)
-  slowdb.db.batch = db.db.batch.bind(db.db)
-  slowdb.db.iterator = db.db.iterator.bind(db.db)
-  slowdb.get = db.get.bind(db)
-  slowdb.put = db.put.bind(db)
-  slowdb.del = db.del.bind(db)
-  slowdb.batch = db.batch.bind(db)
-  slowdb.createReadStream = db.createReadStream.bind(db)
-  slowdb.isOpen = db.isOpen.bind(db)
-  db.on('open', slowdb.emit.bind(slowdb, 'open'))
-  return slowdb
 }
 
 module.exports = testServer


### PR DESCRIPTION
This happens where a map query is made with 'forks' disabled, meaning only
the latest version of each OSM element is returned.

In some cases an OSM 'way' that is excluded will reference OSM nodes that
are not present in the way that is ultimately returned. Prior to this
commit, those ways' unreferenced nodes would be returned regardless,
resulting in the final map being peppered with unlabeled
"ghost points", with no way referencing them.

This fixes the issue by tracking which nodes are referenced to by ways that
are excluded, and filtering them out of the final result.