### PR TITLE
faster hex to decimal conversion

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,5 @@
 var contentType = require('content-type')
 var randombytes = require('randombytes')
-var convert = require('base-convertor')
 var JSONStream = require('JSONStream')
 
 var version = require('../package.json').version
@@ -81,7 +80,11 @@ function generateId () {
 }
 
 function hex2dec (hex) {
-  return convert(hex.toUpperCase(), '0123456789ABCDEF', '0123456789')
+  var d = ''
+  for (var i=hex.length-5; i > -5; i-=5) { // LCM of 16 and 10 is 16*5
+    d = parseInt(hex.slice(Math.max(0,i),i+5),16) + d
+  }
+  return d
 }
 
 function isValidContentType (req) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "JSONStream": "^1.1.4",
     "accepts": "^1.3.3",
-    "base-convertor": "^1.1.0",
     "collect-stream": "^1.1.1",
     "collect-transform-stream": "0.0.2",
     "content-type": "^1.0.2",


### PR DESCRIPTION
As part of some ongoing performance improvements we identified hex2dec as a piece of code that gets called a lot and could be improved. This doesn't move the needle much on total time for bulk imports, but this patch should improve hex2dec perf about 4-fold from 58ms to 14ms:

```
> var convert = require('base-convertor'); var start = Date.now(); for (var i = 0; i < 1000; i++) convert('abc123','0123456789abcdef','0123456789'); Date.now() - start
58
> function newconvert (s) { var d=''; for (var i=s.length-5; i>-5; i-=5) d = parseInt(s.slice(Math.max(0,i),i+5),16)+d; return d }
> var start = Date.now(); for (var i = 0; i < 1000; i++) newconvert('abc123'); Date.now() - start 
14
```