### PR TITLE
node attributes should also contain a version

### DIFF
--- a/test/bbox.js
+++ b/test/bbox.js
@@ -100,7 +100,7 @@ test('add docs to changeset', function (t) {
 })
 
 test('bbox', function (t) {
-  t.plan(8 + SIZE * 3)
+  t.plan(8 + SIZE * 4)
   var href = base + 'map?bbox=-123,63,-120,66'
   var hq = hyperquest(href)
   hq.once('response', function (res) {
@@ -180,7 +180,7 @@ test('out of range bbox', function (t) {
 })
 
 test('bbox json', function (t) {
-  t.plan(7 + SIZE * 3)
+  t.plan(7 + SIZE * 4)
   var href = base + 'map?bbox=-123,63,-120,66'
   var hq = hyperquest(href, {headers: { 'Accept': 'application/json' }})
   hq.once('response', function (res) {

--- a/test/bbox.js
+++ b/test/bbox.js
@@ -120,6 +120,7 @@ test('bbox', function (t) {
       var c = xml.root.children[i]
       var node = uploaded[c.attributes.id]
       if (c.name === 'node') {
+        t.ok(c.attributes.version)
         t.equal(c.attributes.changeset, node.changeset)
         t.equal(c.attributes.lat, String(node.lat))
         t.equal(c.attributes.lon, String(node.lon))
@@ -198,6 +199,7 @@ test('bbox json', function (t) {
       var c = json.elements[i]
       var node = uploaded[c.id]
       if (c.type === 'node') {
+        t.ok(c.version)
         t.equal(c.changeset, node.changeset)
         t.equal(c.lat, node.lat)
         t.equal(c.lon, node.lon)


### PR DESCRIPTION
Although it wasn't tested, the last version of osm-p2p-server's `map?bbox` route would return nodes that had a `version` property. For example,
``` { type: 'node',
  changeset: '3142142805352922006',
  lat: 64.98,
  lon: -121.98,
  timestamp: '2019-03-29T19:56:02.654Z',
  id: '9668467094617189336',
  version:
   '03f23d77b9c37692f66657b2c2f1e8e87e522c197f3e12f1d4d4c4aea6bec07c' }
```

This PR adds a test that ensures nodes have attributes that contain a `version`.
