### PR TITLE
update osm-p2p-server for new kappa structure

### DIFF
--- a/api/get_map.js
+++ b/api/get_map.js
@@ -23,10 +23,10 @@ module.exports = function (osm) {
     var nodesSeen = {}
     var deletionFilter = through.obj(function (chunk, enc, next) {
       if (!chunk.deleted) {
-        if (chunk.element && chunk.element.type === 'node') {
+        if (chunk && chunk.type === 'node') {
           nodesSeen[chunk.id] = true
-        } else if (chunk.element && chunk.element.type === 'way') {
-          chunk.element.refs = (chunk.element.refs || []).filter(function (id) {
+        } else if (chunk && chunk.type === 'way') {
+          chunk.refs = (chunk.refs || []).filter(function (id) {
             return !!nodesSeen[id]
           })
         }
@@ -77,10 +77,10 @@ function orderByType () {
   var queue = { ways: [], relations: [] }
   return through.obj(write, end)
   function write (chunk, enc, next) {
-    if (chunk && chunk.element && chunk.element.type === 'way') {
+    if (chunk && chunk && chunk.type === 'way') {
       queue.ways.push(chunk)
       next()
-    } else if (chunk && chunk.element && chunk.element.type === 'relation') {
+    } else if (chunk && chunk.type === 'relation') {
       queue.relations.push(chunk)
       next()
     } else {
@@ -101,12 +101,12 @@ function orderByType () {
 
 function refs2nodes (doc) {
   var element = { id: doc.id }
-  for (var prop in doc.element) {
-    if (!doc.element.hasOwnProperty(prop)) continue
+  for (var prop in doc) {
+    if (!doc.hasOwnProperty(prop)) continue
     if (prop === 'refs') {
-      element.nodes = doc.element.refs
+      element.nodes = doc.refs
     } else {
-      element[prop] = doc.element[prop]
+      element[prop] = doc[prop]
     }
   }
   return element

--- a/lib/check_ref_ex.js
+++ b/lib/check_ref_ex.js
@@ -9,7 +9,7 @@ module.exports = function (osm) {
   function write (row, enc, next) {
     var pending = 1
     var nrefs = []
-    ;((row.element && row.element.refs) || []).forEach(function (ref, i) {
+    ;((row && row.refs) || []).forEach(function (ref, i) {
       pending++
       osm.get(ref, function (err, docs) {
         if (err) return next(err)
@@ -19,7 +19,7 @@ module.exports = function (osm) {
       })
     })
     var nmembers = []
-    ;((row.element && row.element.members) || []).forEach(function (m, i) {
+    ;((row && row.members) || []).forEach(function (m, i) {
       pending++
       osm.get(m.ref, function (err, doc) {
         if (err) return next(err)
@@ -31,10 +31,10 @@ module.exports = function (osm) {
     if (--pending === 0) done()
 
     function done () {
-      if (row.element && row.element.refs) {
-        row.element.refs = nrefs.filter(Boolean)
+      if (row && row.refs) {
+        row.refs = nrefs.filter(Boolean)
       }
-      if (row.element && row.element.members) {
+      if (row && row.members) {
         row.members = nmembers.filter(Boolean)
       }
       next(null, row)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "random-access-memory": "^2.4.0",
     "run-waterfall": "^1.1.3",
     "standard": "^8.0.0",
-    "tap": "^10.1.0",
     "tape": "^4.4.0",
     "tmp": "^0.1.0",
     "xml-parser": "^1.2.1"
@@ -82,7 +81,7 @@
     "example": "example"
   },
   "scripts": {
-    "test": "nyc tap --no-timeout -j4 'test/*.js' 'test/lib/*.test.js' 'test/api/*.test.js'",
+    "test": "tape 'test/*.js' 'test/lib/*.test.js' 'test/api/*.test.js'",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "lint": "standard"
   },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "standard": "^8.0.0",
     "tap": "^10.1.0",
     "tape": "^4.4.0",
+    "tmp": "^0.1.0",
     "xml-parser": "^1.2.1"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "hyperquest": "^2.0.0",
     "isostring": "0.0.1",
     "kappa-core": "^2.0.0",
-    "kappa-osm": "^2.0.0",
+    "kappa-osm": "^3.0.0",
     "memdb": "^1.3.1",
     "memory-chunk-store": "github:noffle/memory-chunk-store",
     "nyc": "^10.1.2",

--- a/test/lib/slowdb.js
+++ b/test/lib/slowdb.js
@@ -26,6 +26,7 @@ function slowdb (opts) {
   slowdb.del = db.del.bind(db)
   slowdb.batch = db.batch.bind(db)
   slowdb.createReadStream = db.createReadStream.bind(db)
+  slowdb.open = db.open.bind(db)
   slowdb.isOpen = db.isOpen.bind(db)
   db.on('open', slowdb.emit.bind(slowdb, 'open'))
   return slowdb

--- a/test/lib/slowdb.js
+++ b/test/lib/slowdb.js
@@ -1,10 +1,12 @@
-var memdb = require('memdb')
+var level = require('level')
+var tmp = require('tmp')
 var EventEmitter = require('events').EventEmitter
 
 function slowdb (opts) {
   opts = opts || {}
   var delay = opts.delay || 100
-  var db = memdb()
+  var dir = tmp.dirSync().name
+  var db = level(dir)
   var slowdb = new EventEmitter()
   slowdb.setMaxListeners(Infinity)
   slowdb.db = {}
@@ -27,6 +29,7 @@ function slowdb (opts) {
   slowdb.batch = db.batch.bind(db)
   slowdb.createReadStream = db.createReadStream.bind(db)
   slowdb.open = db.open.bind(db)
+  slowdb.iterator = db.iterator.bind(db)
   slowdb.isOpen = db.isOpen.bind(db)
   db.on('open', slowdb.emit.bind(slowdb, 'open'))
   return slowdb


### PR DESCRIPTION
This removes dependence upon `element` property by updating to the new flattened kappa-osm structure. This PR depends upon https://github.com/digidem/kappa-osm/pull/8