### PR TITLE
Update to Level v5

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '6'
 - '8'
 - '10'
+- '12'
 os:
 - windows
 - osx

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^2.2.0",
     "from2-array": "0.0.4",
     "inherits": "^2.0.1",
-    "level": "^4.0.0",
+    "level": "^5.0.1",
     "minimist": "^1.2.0",
     "mkdirp": "~0.5.1",
     "obj2osm": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "maps",
     "geo"
   ],
-  "author": [
+  "authors": [
     "substack",
     "gmaclennan",
     "noffle"
@@ -60,17 +60,16 @@
   "devDependencies": {
     "codecov": "^1.0.1",
     "concat-stream": "^1.6.0",
+    "end-of-stream": "^1.4.1",
     "express": "^4.14.0",
-    "hyperlog": "^4.10.0",
     "hyperquest": "^2.0.0",
     "isostring": "0.0.1",
-    "kappa-core": "^2.0.0",
+    "kappa-core": "^4.0.0",
     "kappa-osm": "^3.0.0",
     "memdb": "^1.3.1",
-    "memory-chunk-store": "github:noffle/memory-chunk-store",
     "nyc": "^10.1.2",
     "random-access-file": "^2.0.1",
-    "random-access-memory": "^2.4.0",
+    "random-access-memory": "^3.1.1",
     "run-waterfall": "^1.1.3",
     "standard": "^8.0.0",
     "tape": "^4.4.0",


### PR DESCRIPTION
Level is only used for the cli, so shouldn't actually change anything. Mapeo Desktop is using this with level v5 already